### PR TITLE
Add HAProxy redirect for 1942.munyard.dev to bfstats.io

### DIFF
--- a/k3s/haproxy/config.yaml
+++ b/k3s/haproxy/config.yaml
@@ -68,23 +68,21 @@ data:
 
       use_backend jenkins if { req.hdr(host) -i jenkins.munyard.dev } 
 
-      use_backend 1942apibackend if host_1942 path_api_backend
+      # Redirect 1942.munyard.dev to bfstats.io with same path
+      http-request redirect scheme https code 301 location https://bfstats.io%[capture.req.uri] if host_1942
+
       use_backend 1942apibackend if host_staging_1942 path_api_backend
       use_backend 1942apibackend if host_bfstats path_api_backend
       use_backend 1942apibackend if host_staging_bfstats path_api_backend
-      use_backend 1942playerapibackend if host_1942 path_player_api_backend
       use_backend 1942playerapibackend if host_staging_1942 path_player_api_backend
       use_backend 1942playerapibackend if host_bfstats path_player_api_backend
       use_backend 1942playerapibackend if host_staging_bfstats path_player_api_backend
-      use_backend 1942aibackend if host_1942 path_ai_backend
       use_backend 1942aibackend if host_staging_1942 path_ai_backend
       use_backend 1942aibackend if host_bfstats path_ai_backend
       use_backend 1942aibackend if host_staging_bfstats path_ai_backend
-      use_backend 1942notifications if host_1942 path_notifications
       use_backend 1942notifications if host_staging_1942 path_notifications
       use_backend 1942notifications if host_bfstats path_notifications
       use_backend 1942notifications if host_staging_bfstats path_notifications
-      use_backend 1942 if host_1942
       use_backend staging1942 if host_staging_1942
       use_backend 1942 if host_bfstats
       use_backend staging1942 if host_staging_bfstats


### PR DESCRIPTION
- Added HTTP 301 redirect rule for 1942.munyard.dev to bfstats.io
- Preserves original URL path in redirect
- Removed 1942.munyard.dev backend routing rules since traffic will be redirected